### PR TITLE
Refactor collectLinks to properly gather hyperlinks

### DIFF
--- a/WebOperator.py
+++ b/WebOperator.py
@@ -69,10 +69,10 @@ def collectLinks():
     global driver
 
     print('Collecting links')
+    link_elements = driver.find_elements_by_xpath("//a[@href]")
     hrefs = []
-    href = driver.find_elements_by_xpath("//a[@href]")
-    for href in hrefs:
-        hrefs.append(str(href.get_attribute("href")))
+    for element in link_elements:
+        hrefs.append(element.get_attribute("href"))
     driver.quit()
     return hrefs
 


### PR DESCRIPTION
## Summary
- fix `collectLinks` to iterate over found link elements and return their `href` values
- retain `driver.quit()` to close the browser after link collection

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68937685eb38832d9973dee8ea2293db